### PR TITLE
Add elastic_transform processing for image.py

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -48,7 +48,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif
@@ -56,6 +56,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           sarif_file: results.sarif

--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -6,6 +6,7 @@ since your modifications would be overwritten.
 
 from keras.src.ops.image import affine_transform
 from keras.src.ops.image import crop_images
+from keras.src.ops.image import elastic_transform
 from keras.src.ops.image import extract_patches
 from keras.src.ops.image import gaussian_blur
 from keras.src.ops.image import hsv_to_rgb

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -6,6 +6,7 @@ since your modifications would be overwritten.
 
 from keras.src.ops.image import affine_transform
 from keras.src.ops.image import crop_images
+from keras.src.ops.image import elastic_transform
 from keras.src.ops.image import extract_patches
 from keras.src.ops.image import gaussian_blur
 from keras.src.ops.image import hsv_to_rgb

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 from keras.src import backend
 from keras.src.backend.jax.core import convert_to_tensor
+from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -729,3 +730,132 @@ def gaussian_blur(
         blurred_images = blurred_images.squeeze(axis=0)
 
     return blurred_images
+
+
+def elastic_transform(
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
+    seed=None,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = jnp.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    seed = draw_seed(seed)
+    dx = (
+        jax.random.normal(
+            seed, shape=(batch_size, height, width), dtype=input_dtype
+        )
+        * sigma
+    )
+    dy = (
+        jax.random.normal(
+            seed, shape=(batch_size, height, width), dtype=input_dtype
+        )
+        * sigma
+    )
+
+    dx = gaussian_blur(
+        jnp.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        jnp.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = jnp.squeeze(dx)
+    dy = jnp.squeeze(dy)
+
+    x, y = jnp.meshgrid(jnp.arange(width), jnp.arange(height))
+    x, y = x[None, :, :], y[None, :, :]
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = jnp.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images = transformed_images.at[..., i].set(
+                jnp.stack(
+                    [
+                        map_coordinates(
+                            images[b, ..., i],
+                            [distorted_y[b], distorted_x[b]],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS[
+                                interpolation
+                            ],
+                            fill_mode=fill_mode,
+                            fill_value=fill_value,
+                        )
+                        for b in range(batch_size)
+                    ]
+                )
+            )
+    else:
+        for i in range(channels):
+            transformed_images = transformed_images.at[:, i, :, :].set(
+                jnp.stack(
+                    [
+                        map_coordinates(
+                            images[b, i, ...],
+                            [distorted_y[b], distorted_x[b]],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS[
+                                interpolation
+                            ],
+                            fill_mode=fill_mode,
+                            fill_value=fill_value,
+                        )
+                        for b in range(batch_size)
+                    ]
+                )
+            )
+
+    if need_squeeze:
+        transformed_images = jnp.squeeze(transformed_images, axis=0)
+    transformed_images = transformed_images.astype(input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from keras.src import backend
 from keras.src.backend.numpy.core import convert_to_tensor
+from keras.src.random.seed_generator import draw_seed
 from keras.src.utils.module_utils import scipy
 
 RESIZE_INTERPOLATIONS = (
@@ -878,3 +879,127 @@ def gaussian_blur(
         blurred_images = np.squeeze(blurred_images, axis=0)
 
     return blurred_images
+
+
+def elastic_transform(
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
+    seed=None,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    input_dtype = images.dtype
+
+    alpha = convert_to_tensor(alpha, dtype=input_dtype)
+    sigma = convert_to_tensor(sigma, dtype=input_dtype)
+
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = np.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    seed = draw_seed(seed)
+    rng = np.random.default_rng(seed)
+    dx = (
+        rng.normal(size=(batch_size, height, width), loc=0.0, scale=1.0).astype(
+            input_dtype
+        )
+        * sigma
+    )
+    dy = (
+        rng.normal(size=(batch_size, height, width), loc=0.0, scale=1.0).astype(
+            input_dtype
+        )
+        * sigma
+    )
+
+    dx = gaussian_blur(
+        np.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        np.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = np.squeeze(dx)
+    dy = np.squeeze(dy)
+
+    x, y = np.meshgrid(np.arange(width), np.arange(height))
+    x, y = x[None, :, :], y[None, :, :]
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = np.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images[..., i] = np.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+    else:
+        for i in range(channels):
+            transformed_images[:, i, :, :] = np.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+
+    if need_squeeze:
+        transformed_images = np.squeeze(transformed_images, axis=0)
+    transformed_images = transformed_images.astype(input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 
 from keras.src import backend
 from keras.src.backend.tensorflow.core import convert_to_tensor
+from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -776,3 +777,141 @@ def gaussian_blur(
         blurred_images = tf.squeeze(blurred_images, axis=0)
 
     return blurred_images
+
+
+def elastic_transform(
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
+    seed=None,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS:
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{AFFINE_TRANSFORM_INTERPOLATIONS}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    input_dtype = images.dtype
+
+    alpha = convert_to_tensor(alpha, dtype=input_dtype)
+    sigma = convert_to_tensor(sigma, dtype=input_dtype)
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = tf.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    seed = draw_seed(seed)
+    dx = tf.random.stateless_normal(
+        shape=(batch_size, height, width),
+        mean=0.0,
+        stddev=1.0,
+        dtype=input_dtype,
+        seed=seed,
+    )
+    dy = tf.random.stateless_normal(
+        shape=(batch_size, height, width),
+        mean=0.0,
+        stddev=1.0,
+        dtype=input_dtype,
+        seed=seed,
+    )
+
+    dx = gaussian_blur(
+        tf.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        tf.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = tf.squeeze(dx, axis=channel_axis)
+    dy = tf.squeeze(dy, axis=channel_axis)
+
+    x, y = tf.meshgrid(
+        tf.range(width, dtype=input_dtype),
+        tf.range(height, dtype=input_dtype),
+        indexing="xy",
+    )
+    x = tf.expand_dims(x, axis=0)
+    y = tf.expand_dims(y, axis=0)
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    channel_outputs = []
+    if data_format == "channels_last":
+        for i in range(channels):
+            channel_transformed = tf.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
+                            interpolation
+                        ),
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ],
+                axis=0,
+            )
+            channel_outputs.append(channel_transformed)
+        transformed_images = tf.stack(channel_outputs, axis=-1)
+    else:
+        for i in range(channels):
+            channel_transformed = tf.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
+                            interpolation
+                        ),
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ],
+                axis=0,
+            )
+            channel_outputs.append(channel_transformed)
+        transformed_images = tf.stack(channel_outputs, axis=1)
+
+    if need_squeeze:
+        transformed_images = tf.squeeze(transformed_images, axis=0)
+    transformed_images = tf.cast(transformed_images, input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -3,10 +3,13 @@ import itertools
 import operator
 
 import torch
+import torch._dynamo as dynamo
 import torch.nn.functional as F
 
 from keras.src import backend
 from keras.src.backend.torch.core import convert_to_tensor
+from keras.src.backend.torch.core import get_device
+from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = {
     "bilinear": "bilinear",
@@ -833,7 +836,6 @@ def gaussian_blur(
             return kernel1d / torch.sum(kernel1d)
 
         def _get_gaussian_kernel2d(size, sigma):
-            size = torch.tensor(size, dtype=dtype)
             kernel1d_x = _get_gaussian_kernel1d(size[0], sigma[0])
             kernel1d_y = _get_gaussian_kernel1d(size[1], sigma[1])
             return torch.outer(kernel1d_y, kernel1d_x)
@@ -868,8 +870,6 @@ def gaussian_blur(
 
     kernel = kernel.expand(num_channels, 1, kernel_size[0], kernel_size[1])
 
-    print(kernel_size[0] // 2)
-
     blurred_images = torch.nn.functional.conv2d(
         images,
         kernel,
@@ -885,3 +885,148 @@ def gaussian_blur(
         blurred_images = blurred_images.squeeze(dim=0)
 
     return blurred_images
+
+
+@dynamo.disable()
+def torch_seed_generator(seed):
+    first_seed, second_seed = draw_seed(seed)
+    device = get_device()
+    if device == "meta":
+        return None
+    generator = torch.Generator(device=get_device())
+    generator.manual_seed(int(first_seed + second_seed))
+    return generator
+
+
+def elastic_transform(
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
+    seed=None,
+    data_format=None,
+):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if images.ndim == 3:
+        images = images.unsqueeze(dim=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    generator = torch_seed_generator(seed) if get_device() == "meta" else None
+    dx = (
+        torch.normal(
+            0.0,
+            1.0,
+            size=(batch_size, height, width),
+            generator=generator,
+            dtype=input_dtype,
+            device=images.device,
+        )
+        * sigma
+    )
+
+    dy = (
+        torch.normal(
+            0.0,
+            1.0,
+            size=(batch_size, height, width),
+            generator=generator,
+            dtype=input_dtype,
+            device=images.device,
+        )
+        * sigma
+    )
+
+    dx = gaussian_blur(
+        dx.unsqueeze(dim=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        dy.unsqueeze(dim=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = dx.squeeze()
+    dy = dy.squeeze()
+
+    x, y = torch.meshgrid(
+        torch.arange(width), torch.arange(height), indexing="xy"
+    )
+    x, y = x.unsqueeze(0), y.unsqueeze(0)
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = torch.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images[..., i] = torch.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+    else:
+        for i in range(channels):
+            transformed_images[:, i, :, :] = torch.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+
+    if need_squeeze:
+        transformed_images = transformed_images.squeeze(0)
+    transformed_images = transformed_images.to(input_dtype)
+
+    return transformed_images


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/20977

I have added the elastic_transform method for NumPy, TensorFlow, Torch, and JAX. If this concept and implementation prove to be effective, I can proceed with adding the ops layer and corresponding test cases.

torchvision's [elastic_transform](https://pytorch.org/vision/main/generated/torchvision.transforms.ElasticTransform.html)
here is my [gist](https://colab.research.google.com/drive/1upYpl7yfeqsO4BXIS1fpeEZmqEBNsH_z?usp=sharing)